### PR TITLE
feat(list,ui): Doorlopende contracten duidelijk tonen; redesign edit-dialoog (a11y)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ coverage/
 
 # Playwright
 playwright-report/
+frontend/test-results/
 
 # Vitest
 *.log

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,5 @@
+{
+  "default": true,
+  "MD007": { "indent": 2 },
+  "MD010": { "code_blocks": true }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,3 +26,10 @@
 - UI: Contract-formulier en bewerk-dialoog hebben een 'Frequentie' selectie; bedragen zijn niet langer per maand hardcoded.
 - Styles: Bewerk-dialoog responsive gemaakt (grid, max-width, padding) met mobile-first layout.
 - Tests: Bestaande tests blijven groen; dekking ongewijzigd. Nieuwe UI is backward-compatible.
+
+2025-08-16 - Bewerk-dialoog UI en toegankelijkheid verbeterd
+
+- UI: Bewerk-dialoog herontworpen met duidelijke header, sticky acties, betere spacing en schaduwen.
+- Toegankelijkheid: role="dialog", aria-modal, titel-koppeling en toetsenbord-navigatie (Esc om te sluiten, focus trap).
+- Codekwaliteit: Geen geneste labels meer; semantische fieldsets en labels toegevoegd.
+- Tests: Extra unit test toegevoegd voor ARIA-structuur.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,3 +12,17 @@
 2025-08-16 - Documentatie: component-links
 
 - Docs: In `docs/frontend-components.md` per component een link toegevoegd naar het bijbehorende bronbestand. Markdown-indents gecorrigeerd.
+
+2025-08-16 - Kosten van contract aanpassen (User Story #8)
+
+- Feature: Bedrag (amount) veld toegevoegd aan contracten (types, repository, UI).
+- UI: Formulier en bewerk-dialoog ondersteunen bedrag invoeren/wijzigen; lijst toont bedrag in euro's.
+- Opslag: Memory en IndexedDB repository slaan amount op en werken het bij.
+- Tests: Unit tests uitgebreid voor form submit (amount) en repository update.
+
+2025-08-16 - Frequentie per verplichting (issue #5) en mobile-first UI
+
+- Feature: PaymentFrequency toegevoegd aan PaymentRate (types) met opties daily/weekly/biweekly/monthly/quarterly/yearly.
+- UI: Contract-formulier en bewerk-dialoog hebben een 'Frequentie' selectie; bedragen zijn niet langer per maand hardcoded.
+- Styles: Bewerk-dialoog responsive gemaakt (grid, max-width, padding) met mobile-first layout.
+- Tests: Bestaande tests blijven groen; dekking ongewijzigd. Nieuwe UI is backward-compatible.

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -12,6 +12,22 @@ classDiagram
     +string accountNumber
     +string description
     +string createdAt
+    +PaymentObligation[] obligations
+  }
+
+  class PaymentObligation {
+    +string id
+    +string label
+    +string createdAt
+    +PaymentRate[] rates
+  }
+
+  class PaymentRate {
+    +string id
+    +number amount
+    +string validFrom
+    +string validTo
+    +string createdAt
   }
 ```
 

--- a/docs/frontend-components.md
+++ b/docs/frontend-components.md
@@ -42,6 +42,9 @@ Source: [contract-list.ts](../frontend/src/components/contract-list.ts)
 	- `edit-request` — detail: `id: string` when the user clicks “Bewerken”.
 - A11y:
 	- Buttons include `aria-label` with contract name.
+ - Display logic:
+ 	- Recurring obligations are shown as a total per frequency when all share the same frequency; otherwise a normalized per-month total is shown ("Terugkerend (per maand): € …/mnd").
+ 	- Installment schedules show the total sum and the number of terms ("Termijnen: € … (n termijnen)").
 
 ## contract-edit
 
@@ -55,7 +58,8 @@ Source: [contract-edit.ts](../frontend/src/components/contract-edit.ts)
 	- `contract-save` — detail: `{ id, input: { name, accountNumber, description?, obligations?: [{ id?, label?, rate?: { amount, frequency?, schedule?, validFrom?, validTo? } }] } }`
 	- `edit-close` — emitted when dialog closes without saving
 - A11y:
-	- Uses a backdrop and card. Note: no focus trap yet; recommended follow-up to add focus management and Escape-to-close.
+	- Accessible modal with role="dialog", aria-modal, labeled by title.
+	- Keyboard: Esc closes, focus is trapped within the dialog, and initial focus is set on open.
 
 ## Types
 

--- a/docs/frontend-components.md
+++ b/docs/frontend-components.md
@@ -21,9 +21,11 @@ Source: [contract-form.ts](../frontend/src/components/contract-form.ts)
 	- name: string (required)
 	- accountNumber: string (required)
 	- description: string (optional)
-	- obligations: array (optional) — minimal UI ondersteunt één verplichting (label) met nieuwe rate `{ amount, frequency, validFrom? }`
+	- obligations: array (optional) — minimal UI ondersteunt één verplichting (label) met nieuwe rate. Twee schema's:
+		- Terugkerend: `{ amount, frequency, schedule: { type: 'recurring', frequency } }`
+		- Termijnen: `{ amount: som van termijnen, schedule: { type: 'installments', installments: [{ date, amount }] } }`
 - Events:
-	- `contract-submit` — detail: `{ name, accountNumber, description?, obligations?: [{ label?, rate?: { amount, frequency, validFrom? } }] }`
+	- `contract-submit` — detail: `{ name, accountNumber, description?, obligations?: [{ label?, rate?: { amount, frequency?, schedule?, validFrom? } }] }`
 	- `form-error` — detail: string (validation message)
 - A11y:
 	- Semantic labels per field.
@@ -50,7 +52,7 @@ Source: [contract-edit.ts](../frontend/src/components/contract-edit.ts)
 	- `open: boolean` — controls visibility
 	- `contract?: Contract` — current contract
 - Events:
-	- `contract-save` — detail: `{ id, input: { name, accountNumber, description?, obligations?: [{ id?, label?, rate?: { amount, frequency, validFrom?, validTo? } }] } }`
+	- `contract-save` — detail: `{ id, input: { name, accountNumber, description?, obligations?: [{ id?, label?, rate?: { amount, frequency?, schedule?, validFrom?, validTo? } }] } }`
 	- `edit-close` — emitted when dialog closes without saving
 - A11y:
 	- Uses a backdrop and card. Note: no focus trap yet; recommended follow-up to add focus management and Escape-to-close.
@@ -67,7 +69,7 @@ interface Contract {
 	name: string;
 	accountNumber: string;
 	description?: string;
-	obligations?: { id: string; label?: string; createdAt: string; rates: { id: string; amount: number; frequency?: 'daily'|'weekly'|'biweekly'|'monthly'|'quarterly'|'yearly'; validFrom: string; validTo?: string; createdAt: string }[] }[];
+	obligations?: { id: string; label?: string; createdAt: string; rates: { id: string; amount: number; frequency?: 'daily'|'weekly'|'biweekly'|'monthly'|'quarterly'|'yearly'; schedule?: { type: 'recurring', frequency: 'daily'|'weekly'|'biweekly'|'monthly'|'quarterly'|'yearly' } | { type: 'installments', installments: { date: string; amount: number }[] }; validFrom: string; validTo?: string; createdAt: string }[] }[];
 	createdAt: string; // ISO
 }
 ```

--- a/docs/frontend-components.md
+++ b/docs/frontend-components.md
@@ -21,8 +21,9 @@ Source: [contract-form.ts](../frontend/src/components/contract-form.ts)
 	- name: string (required)
 	- accountNumber: string (required)
 	- description: string (optional)
+	- obligations: array (optional) — minimal UI ondersteunt één verplichting (label) met nieuwe rate `{ amount, frequency, validFrom? }`
 - Events:
-	- `contract-submit` — detail: `{ name, accountNumber, description? }`
+	- `contract-submit` — detail: `{ name, accountNumber, description?, obligations?: [{ label?, rate?: { amount, frequency, validFrom? } }] }`
 	- `form-error` — detail: string (validation message)
 - A11y:
 	- Semantic labels per field.
@@ -49,7 +50,7 @@ Source: [contract-edit.ts](../frontend/src/components/contract-edit.ts)
 	- `open: boolean` — controls visibility
 	- `contract?: Contract` — current contract
 - Events:
-	- `contract-save` — detail: `{ id, input: { name, accountNumber, description? } }`
+	- `contract-save` — detail: `{ id, input: { name, accountNumber, description?, obligations?: [{ id?, label?, rate?: { amount, frequency, validFrom?, validTo? } }] } }`
 	- `edit-close` — emitted when dialog closes without saving
 - A11y:
 	- Uses a backdrop and card. Note: no focus trap yet; recommended follow-up to add focus management and Escape-to-close.
@@ -66,6 +67,7 @@ interface Contract {
 	name: string;
 	accountNumber: string;
 	description?: string;
+	obligations?: { id: string; label?: string; createdAt: string; rates: { id: string; amount: number; frequency?: 'daily'|'weekly'|'biweekly'|'monthly'|'quarterly'|'yearly'; validFrom: string; validTo?: string; createdAt: string }[] }[];
 	createdAt: string; // ISO
 }
 ```

--- a/frontend/src/components/contract-edit.ts
+++ b/frontend/src/components/contract-edit.ts
@@ -1,6 +1,6 @@
 import { LitElement, html, css } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
-import type { Contract, NewContractInput, PaymentFrequency } from '../types';
+import type { Contract, NewContractInput, PaymentFrequency, PaymentScheduleInput } from '../types';
 
 @customElement('contract-edit')
 export class ContractEdit extends LitElement {
@@ -22,6 +22,9 @@ export class ContractEdit extends LitElement {
   @state() private description = '';
   @state() private amount: string = '';
   @state() private frequency: PaymentFrequency = 'monthly';
+  @state() private scheduleType: 'recurring' | 'installments' = 'recurring';
+  @state() private termsCount: string = '0';
+  @state() private installments: { date: string; amount: string }[] = [];
   @state() private obligationLabel: string = '';
 
   updated(changed: Map<string, unknown>) {
@@ -33,7 +36,15 @@ export class ContractEdit extends LitElement {
   const now = Date.now();
   const current = first?.rates?.filter(r => (!r.validFrom || Date.parse(r.validFrom) <= now) && (!r.validTo || Date.parse(r.validTo) >= now)).slice(-1)[0];
   this.amount = current ? String(current.amount) : '';
-  this.frequency = (current?.frequency ?? 'monthly') as PaymentFrequency;
+  if (current?.schedule?.type === 'installments') {
+    this.scheduleType = 'installments';
+    const ins = current.schedule.installments ?? [];
+    this.termsCount = String(ins.length);
+    this.installments = ins.map(i => ({ date: i.date, amount: String(i.amount) }));
+  } else {
+    this.scheduleType = 'recurring';
+    this.frequency = (current?.schedule?.type === 'recurring' ? current.schedule.frequency : (current?.frequency ?? 'monthly')) as PaymentFrequency;
+  }
   this.obligationLabel = first?.label ?? '';
     }
   }
@@ -46,14 +57,28 @@ export class ContractEdit extends LitElement {
   private submit(e: Event) {
     e.preventDefault();
     if (!this.contract) return;
+    // Build rate from UI state
+    let rate: { amount: number; frequency?: PaymentFrequency; schedule?: PaymentScheduleInput } | undefined;
+    if (this.scheduleType === 'recurring' && this.amount.trim() !== '') {
+      rate = { amount: Number(this.amount), frequency: this.frequency, schedule: { type: 'recurring', frequency: this.frequency } };
+    } else if (this.scheduleType === 'installments') {
+      const count = Number(this.termsCount) || 0;
+      const filled = this.installments.slice(0, count).filter(t => t.date && t.amount.trim() !== '');
+      const installments = filled.map(t => ({ date: t.date, amount: Number(t.amount) }));
+      const total = installments.reduce((s, i) => s + (isFinite(i.amount) ? i.amount : 0), 0);
+      if (count > 0 && filled.length === count) {
+        rate = { amount: total, schedule: { type: 'installments', installments } };
+      }
+    }
+
     const input: NewContractInput = {
       name: this.name.trim(),
       accountNumber: this.accountNumber.trim(),
       description: this.description.trim() || undefined,
-      obligations: this.amount.trim() !== '' ? [{
+      obligations: rate ? [{
         id: this.contract.obligations?.[0]?.id, // append rate to first obligation if exists
         label: this.obligationLabel.trim() || undefined,
-        rate: { amount: Number(this.amount), frequency: this.frequency },
+        rate,
       }] : [],
     };
     if (!input.name || !input.accountNumber) return;
@@ -78,21 +103,68 @@ export class ContractEdit extends LitElement {
                 <input name="accountNumber" .value=${this.accountNumber} @input=${(e: InputEvent) => (this.accountNumber = (e.target as HTMLInputElement).value)} />
               </label>
               <label>
-                Frequentie
-                <select name="frequency" .value=${this.frequency} @change=${(e: Event) => (this.frequency = (e.target as HTMLSelectElement).value as PaymentFrequency)}>
-                  <option value="daily">Dagelijks</option>
-                  <option value="weekly">Wekelijks</option>
-                  <option value="biweekly">Tweewekelijks</option>
-                  <option value="monthly">Maandelijks</option>
-                  <option value="quarterly">Per kwartaal</option>
-                  <option value="yearly">Jaarlijks</option>
+                Schema
+                <select name="scheduleType" .value=${this.scheduleType} @change=${(e: Event) => (this.scheduleType = (e.target as HTMLSelectElement).value as 'recurring' | 'installments')}>
+                  <option value="recurring">Terugkerend</option>
+                  <option value="installments">Termijnen</option>
                 </select>
               </label>
               <label>
-                Bedrag (€)
-                <input name="amount" type="number" min="0" step="0.01" .value=${this.amount} @input=${(e: InputEvent) => (this.amount = (e.target as HTMLInputElement).value)} />
-              </label>
-              <label>
+            ${this.scheduleType === 'recurring' ? html`
+              <div class="row">
+                <label>
+                  Bedrag (€)
+                  <input name="amount" type="number" min="0" step="0.01" .value=${this.amount} @input=${(e: InputEvent) => (this.amount = (e.target as HTMLInputElement).value)} />
+                </label>
+                <label>
+                  Frequentie
+                  <select name="frequency" .value=${this.frequency} @change=${(e: Event) => (this.frequency = (e.target as HTMLSelectElement).value as PaymentFrequency)}>
+                    <option value="daily">Dagelijks</option>
+                    <option value="weekly">Wekelijks</option>
+                    <option value="biweekly">Tweewekelijks</option>
+                    <option value="monthly">Maandelijks</option>
+                    <option value="quarterly">Per kwartaal</option>
+                    <option value="yearly">Jaarlijks</option>
+                  </select>
+                </label>
+              </div>
+            ` : html`
+              <div class="row">
+                <label>
+                  Aantal termijnen
+                  <input name="termsCount" type="number" min="0" step="1" .value=${this.termsCount} @input=${(e: InputEvent) => {
+                    const v = (e.target as HTMLInputElement).value;
+                    this.termsCount = v;
+                    const n = Math.max(0, Number(v) || 0);
+                    if (n > this.installments.length) {
+                      this.installments = [...this.installments, ...Array.from({ length: n - this.installments.length }, () => ({ date: '', amount: '' }))];
+                    } else if (n < this.installments.length) {
+                      this.installments = this.installments.slice(0, n);
+                    }
+                  }} />
+                </label>
+              </div>
+              ${Number(this.termsCount) > 0 ? html`
+                <div style="display: grid; gap: .5rem;">
+                  ${this.installments.slice(0, Number(this.termsCount)).map((t, idx) => html`
+                    <div class="row" style="align-items:end;">
+                      <label>
+                        Datum
+                        <input type="date" .value=${t.date} @input=${(e: InputEvent) => {
+                          const v = (e.target as HTMLInputElement).value; this.installments = this.installments.map((it, i) => i === idx ? { ...it, date: v } : it);
+                        }} />
+                      </label>
+                      <label>
+                        Bedrag (€)
+                        <input type="number" min="0" step="0.01" .value=${t.amount} @input=${(e: InputEvent) => {
+                          const v = (e.target as HTMLInputElement).value; this.installments = this.installments.map((it, i) => i === idx ? { ...it, amount: v } : it);
+                        }} />
+                      </label>
+                    </div>
+                  `)}
+                </div>
+              ` : null}
+            `}
                 Omschrijving verplichting
                 <input name="obligationLabel" .value=${this.obligationLabel} @input=${(e: InputEvent) => (this.obligationLabel = (e.target as HTMLInputElement).value)} />
               </label>

--- a/frontend/src/components/contract-edit.ts
+++ b/frontend/src/components/contract-edit.ts
@@ -1,17 +1,17 @@
 import { LitElement, html, css } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
-import type { Contract, NewContractInput } from '../types';
+import type { Contract, NewContractInput, PaymentFrequency } from '../types';
 
 @customElement('contract-edit')
 export class ContractEdit extends LitElement {
   static styles = css`
-    .backdrop { position: fixed; inset: 0; background: rgba(0,0,0,.3); display: grid; place-items: center; }
-    .card { background: white; padding: 1rem; border-radius: 12px; min-width: 320px; max-width: 520px; }
-    form { display: grid; gap: .5rem; }
+  .backdrop { position: fixed; inset: 0; background: rgba(0,0,0,.3); display: grid; place-items: center; padding: 1rem; }
+  .card { background: white; padding: 1rem; border-radius: 12px; width: 100%; max-width: 560px; }
+  form { display: grid; gap: .75rem; }
     label { display: grid; gap: .25rem; }
-    .row { display: flex; gap: .5rem; }
-    .row > * { flex: 1; }
-    button { padding: 0.6rem 1rem; }
+  .row { display: grid; grid-template-columns: 1fr; gap: .5rem; }
+  @media (min-width: 640px) { .row { grid-template-columns: 1fr 1fr; } }
+  button { padding: 0.7rem 1rem; }
   `;
 
   @property({ type: Object }) contract?: Contract;
@@ -20,12 +20,21 @@ export class ContractEdit extends LitElement {
   @state() private name = '';
   @state() private accountNumber = '';
   @state() private description = '';
+  @state() private amount: string = '';
+  @state() private frequency: PaymentFrequency = 'monthly';
+  @state() private obligationLabel: string = '';
 
   updated(changed: Map<string, unknown>) {
     if (changed.has('contract') && this.contract) {
       this.name = this.contract.name;
       this.accountNumber = this.contract.accountNumber;
       this.description = this.contract.description ?? '';
+  const first = this.contract.obligations?.[0];
+  const now = Date.now();
+  const current = first?.rates?.filter(r => (!r.validFrom || Date.parse(r.validFrom) <= now) && (!r.validTo || Date.parse(r.validTo) >= now)).slice(-1)[0];
+  this.amount = current ? String(current.amount) : '';
+  this.frequency = (current?.frequency ?? 'monthly') as PaymentFrequency;
+  this.obligationLabel = first?.label ?? '';
     }
   }
 
@@ -41,6 +50,11 @@ export class ContractEdit extends LitElement {
       name: this.name.trim(),
       accountNumber: this.accountNumber.trim(),
       description: this.description.trim() || undefined,
+      obligations: this.amount.trim() !== '' ? [{
+        id: this.contract.obligations?.[0]?.id, // append rate to first obligation if exists
+        label: this.obligationLabel.trim() || undefined,
+        rate: { amount: Number(this.amount), frequency: this.frequency },
+      }] : [],
     };
     if (!input.name || !input.accountNumber) return;
     this.dispatchEvent(new CustomEvent('contract-save', { detail: { id: this.contract.id, input }, bubbles: true, composed: true }));
@@ -62,6 +76,25 @@ export class ContractEdit extends LitElement {
               <label>
                 Rekeningnummer
                 <input name="accountNumber" .value=${this.accountNumber} @input=${(e: InputEvent) => (this.accountNumber = (e.target as HTMLInputElement).value)} />
+              </label>
+              <label>
+                Frequentie
+                <select name="frequency" .value=${this.frequency} @change=${(e: Event) => (this.frequency = (e.target as HTMLSelectElement).value as PaymentFrequency)}>
+                  <option value="daily">Dagelijks</option>
+                  <option value="weekly">Wekelijks</option>
+                  <option value="biweekly">Tweewekelijks</option>
+                  <option value="monthly">Maandelijks</option>
+                  <option value="quarterly">Per kwartaal</option>
+                  <option value="yearly">Jaarlijks</option>
+                </select>
+              </label>
+              <label>
+                Bedrag (€)
+                <input name="amount" type="number" min="0" step="0.01" .value=${this.amount} @input=${(e: InputEvent) => (this.amount = (e.target as HTMLInputElement).value)} />
+              </label>
+              <label>
+                Omschrijving verplichting
+                <input name="obligationLabel" .value=${this.obligationLabel} @input=${(e: InputEvent) => (this.obligationLabel = (e.target as HTMLInputElement).value)} />
               </label>
             </div>
             <label>

--- a/frontend/src/components/contract-edit.ts
+++ b/frontend/src/components/contract-edit.ts
@@ -1,17 +1,28 @@
 import { LitElement, html, css } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
-import type { Contract, NewContractInput, PaymentFrequency, PaymentScheduleInput } from '../types';
+import type { Contract, NewContractInput, PaymentFrequency, PaymentRateInput } from '../types';
 
 @customElement('contract-edit')
 export class ContractEdit extends LitElement {
   static styles = css`
-  .backdrop { position: fixed; inset: 0; background: rgba(0,0,0,.3); display: grid; place-items: center; padding: 1rem; }
-  .card { background: white; padding: 1rem; border-radius: 12px; width: 100%; max-width: 560px; }
-  form { display: grid; gap: .75rem; }
-    label { display: grid; gap: .25rem; }
-  .row { display: grid; grid-template-columns: 1fr; gap: .5rem; }
-  @media (min-width: 640px) { .row { grid-template-columns: 1fr 1fr; } }
-  button { padding: 0.7rem 1rem; }
+  .backdrop { position: fixed; inset: 0; background: rgba(0,0,0,.45); display: grid; place-items: center; padding: 1rem; z-index: 1000; }
+  .dialog { background: #fff; color: #111; border-radius: 12px; width: 100%; max-width: 640px; box-shadow: 0 10px 30px rgba(0,0,0,.25); display: grid; grid-template-rows: auto 1fr auto; max-height: min(90vh, 900px); outline: none; }
+  .header { display: flex; align-items: center; justify-content: space-between; gap: .5rem; padding: 1rem 1rem .75rem 1rem; border-bottom: 1px solid #eee; position: sticky; top: 0; background: #fff; border-top-left-radius: 12px; border-top-right-radius: 12px; }
+  .title { margin: 0; font-size: 1.1rem; }
+  .content { padding: 1rem; overflow: auto; display: grid; gap: 1rem; }
+  form { display: grid; gap: 1rem; }
+  fieldset { border: 1px solid #eee; border-radius: 8px; padding: .75rem; }
+  legend { font-weight: 600; padding: 0 .35rem; }
+  label { display: grid; gap: .25rem; }
+  input, select, textarea { font: inherit; padding: .6rem .7rem; border-radius: 8px; border: 1px solid #cfcfcf; }
+  textarea { resize: vertical; }
+  .grid { display: grid; grid-template-columns: 1fr; gap: .75rem; }
+  @media (min-width: 640px) { .grid.cols-2 { grid-template-columns: 1fr 1fr; } }
+  .actions { display: flex; gap: .75rem; justify-content: flex-end; padding: .75rem 1rem 1rem; border-top: 1px solid #eee; position: sticky; bottom: 0; background: #fff; border-bottom-left-radius: 12px; border-bottom-right-radius: 12px; }
+  .btn { padding: .65rem 1rem; border-radius: 8px; border: 1px solid #cfcfcf; background: #f7f7f7; cursor: pointer; }
+  .btn.primary { background: #0d6efd; border-color: #0d6efd; color: #fff; }
+  .icon { background: transparent; border: none; cursor: pointer; font-size: 1.3rem; width: 2rem; height: 2rem; border-radius: 6px; }
+  .icon:hover { background: #f3f3f3; }
   `;
 
   @property({ type: Object }) contract?: Contract;
@@ -22,10 +33,33 @@ export class ContractEdit extends LitElement {
   @state() private description = '';
   @state() private amount: string = '';
   @state() private frequency: PaymentFrequency = 'monthly';
+  @state() private validFromDate: string = '';
   @state() private scheduleType: 'recurring' | 'installments' = 'recurring';
   @state() private termsCount: string = '0';
   @state() private installments: { date: string; amount: string }[] = [];
   @state() private obligationLabel: string = '';
+
+  private handleKeydown = (e: KeyboardEvent) => {
+    if (e.key === 'Escape') { e.stopPropagation(); this.close(); return; }
+    if (e.key === 'Tab') {
+      // Focus trap within dialog
+      const root = this.shadowRoot!;
+      const container = root.querySelector('.dialog') as HTMLElement | null;
+      if (!container) return;
+      const focusables = Array.from(container.querySelectorAll<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      )).filter(el => !el.hasAttribute('disabled') && el.tabIndex !== -1);
+      if (focusables.length === 0) return;
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      const active = (this.getRootNode() as Document | ShadowRoot).activeElement as HTMLElement | null;
+      if (e.shiftKey) {
+        if (active === first || !container.contains(active)) { last.focus(); e.preventDefault(); }
+      } else {
+        if (active === last) { first.focus(); e.preventDefault(); }
+      }
+    }
+  };
 
   updated(changed: Map<string, unknown>) {
     if (changed.has('contract') && this.contract) {
@@ -41,11 +75,19 @@ export class ContractEdit extends LitElement {
     const ins = current.schedule.installments ?? [];
     this.termsCount = String(ins.length);
     this.installments = ins.map(i => ({ date: i.date, amount: String(i.amount) }));
+    this.validFromDate = current.validFrom ? current.validFrom.slice(0, 10) : '';
   } else {
     this.scheduleType = 'recurring';
     this.frequency = (current?.schedule?.type === 'recurring' ? current.schedule.frequency : (current?.frequency ?? 'monthly')) as PaymentFrequency;
+    this.validFromDate = current?.validFrom ? current.validFrom.slice(0, 10) : '';
   }
   this.obligationLabel = first?.label ?? '';
+    }
+    if (changed.has('open') && this.open) {
+      // Move focus into dialog when opened
+      const root = this.shadowRoot!;
+      const dlg = root.querySelector('.dialog') as HTMLElement | null;
+      if (dlg) setTimeout(() => dlg.focus(), 0);
     }
   }
 
@@ -58,16 +100,20 @@ export class ContractEdit extends LitElement {
     e.preventDefault();
     if (!this.contract) return;
     // Build rate from UI state
-    let rate: { amount: number; frequency?: PaymentFrequency; schedule?: PaymentScheduleInput } | undefined;
+  let rate: PaymentRateInput | undefined;
     if (this.scheduleType === 'recurring' && this.amount.trim() !== '') {
-      rate = { amount: Number(this.amount), frequency: this.frequency, schedule: { type: 'recurring', frequency: this.frequency } };
+      const validFrom = this.validFromDate ? new Date(this.validFromDate).toISOString() : undefined;
+  rate = { amount: Number(this.amount), frequency: this.frequency, schedule: { type: 'recurring', frequency: this.frequency }, validFrom };
     } else if (this.scheduleType === 'installments') {
       const count = Number(this.termsCount) || 0;
       const filled = this.installments.slice(0, count).filter(t => t.date && t.amount.trim() !== '');
       const installments = filled.map(t => ({ date: t.date, amount: Number(t.amount) }));
       const total = installments.reduce((s, i) => s + (isFinite(i.amount) ? i.amount : 0), 0);
       if (count > 0 && filled.length === count) {
-        rate = { amount: total, schedule: { type: 'installments', installments } };
+        // validFrom: explicit, else earliest installment date
+        const earliest = installments.length ? installments.map(i => Date.parse(i.date)).reduce((a, b) => Math.min(a, b)) : undefined;
+        const validFrom = this.validFromDate ? Date.parse(this.validFromDate) : earliest;
+  rate = { amount: total, schedule: { type: 'installments', installments }, validFrom: validFrom && isFinite(validFrom) ? new Date(validFrom).toISOString() : undefined };
       }
     }
 
@@ -90,94 +136,123 @@ export class ContractEdit extends LitElement {
     if (!this.open || !this.contract) return null;
     return html`
       <div class="backdrop" @click=${this.close}>
-        <div class="card" @click=${(e: Event) => e.stopPropagation()}>
-          <h3>Contract bewerken</h3>
-          <form @submit=${this.submit}>
-            <label>
-              Naam
-              <input name="name" .value=${this.name} @input=${(e: InputEvent) => (this.name = (e.target as HTMLInputElement).value)} />
-            </label>
-            <div class="row">
-              <label>
-                Rekeningnummer
-                <input name="accountNumber" .value=${this.accountNumber} @input=${(e: InputEvent) => (this.accountNumber = (e.target as HTMLInputElement).value)} />
-              </label>
-              <label>
-                Schema
-                <select name="scheduleType" .value=${this.scheduleType} @change=${(e: Event) => (this.scheduleType = (e.target as HTMLSelectElement).value as 'recurring' | 'installments')}>
-                  <option value="recurring">Terugkerend</option>
-                  <option value="installments">Termijnen</option>
-                </select>
-              </label>
-              <label>
-            ${this.scheduleType === 'recurring' ? html`
-              <div class="row">
-                <label>
-                  Bedrag (€)
-                  <input name="amount" type="number" min="0" step="0.01" .value=${this.amount} @input=${(e: InputEvent) => (this.amount = (e.target as HTMLInputElement).value)} />
-                </label>
-                <label>
-                  Frequentie
-                  <select name="frequency" .value=${this.frequency} @change=${(e: Event) => (this.frequency = (e.target as HTMLSelectElement).value as PaymentFrequency)}>
-                    <option value="daily">Dagelijks</option>
-                    <option value="weekly">Wekelijks</option>
-                    <option value="biweekly">Tweewekelijks</option>
-                    <option value="monthly">Maandelijks</option>
-                    <option value="quarterly">Per kwartaal</option>
-                    <option value="yearly">Jaarlijks</option>
-                  </select>
-                </label>
-              </div>
-            ` : html`
-              <div class="row">
-                <label>
-                  Aantal termijnen
-                  <input name="termsCount" type="number" min="0" step="1" .value=${this.termsCount} @input=${(e: InputEvent) => {
-                    const v = (e.target as HTMLInputElement).value;
-                    this.termsCount = v;
-                    const n = Math.max(0, Number(v) || 0);
-                    if (n > this.installments.length) {
-                      this.installments = [...this.installments, ...Array.from({ length: n - this.installments.length }, () => ({ date: '', amount: '' }))];
-                    } else if (n < this.installments.length) {
-                      this.installments = this.installments.slice(0, n);
-                    }
-                  }} />
-                </label>
-              </div>
-              ${Number(this.termsCount) > 0 ? html`
-                <div style="display: grid; gap: .5rem;">
-                  ${this.installments.slice(0, Number(this.termsCount)).map((t, idx) => html`
-                    <div class="row" style="align-items:end;">
-                      <label>
-                        Datum
-                        <input type="date" .value=${t.date} @input=${(e: InputEvent) => {
-                          const v = (e.target as HTMLInputElement).value; this.installments = this.installments.map((it, i) => i === idx ? { ...it, date: v } : it);
-                        }} />
-                      </label>
-                      <label>
-                        Bedrag (€)
-                        <input type="number" min="0" step="0.01" .value=${t.amount} @input=${(e: InputEvent) => {
-                          const v = (e.target as HTMLInputElement).value; this.installments = this.installments.map((it, i) => i === idx ? { ...it, amount: v } : it);
-                        }} />
-                      </label>
-                    </div>
-                  `)}
+        <div
+          class="dialog"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="edit-title"
+          @click=${(e: Event) => e.stopPropagation()}
+          @keydown=${this.handleKeydown}
+          tabindex="-1"
+        >
+          <div class="header">
+            <h2 id="edit-title" class="title">Contract bewerken</h2>
+            <button type="button" class="icon" aria-label="Sluiten" @click=${this.close}>&times;</button>
+          </div>
+          <div class="content">
+            <form @submit=${this.submit}>
+              <fieldset>
+                <legend>Contract</legend>
+                <div class="grid cols-2">
+                  <label for="name">
+                    Naam
+                    <input id="name" name="name" .value=${this.name} @input=${(e: InputEvent) => (this.name = (e.target as HTMLInputElement).value)} />
+                  </label>
+                  <label for="accountNumber">
+                    Rekeningnummer
+                    <input id="accountNumber" name="accountNumber" .value=${this.accountNumber} @input=${(e: InputEvent) => (this.accountNumber = (e.target as HTMLInputElement).value)} />
+                  </label>
                 </div>
-              ` : null}
-            `}
-                Omschrijving verplichting
-                <input name="obligationLabel" .value=${this.obligationLabel} @input=${(e: InputEvent) => (this.obligationLabel = (e.target as HTMLInputElement).value)} />
-              </label>
-            </div>
-            <label>
-              Omschrijving
-              <textarea name="description" .value=${this.description} @input=${(e: InputEvent) => (this.description = (e.target as HTMLTextAreaElement).value)} rows="3"></textarea>
-            </label>
-            <div class="row">
-              <button type="button" @click=${this.close}>Annuleren</button>
-              <button type="submit">Opslaan</button>
-            </div>
-          </form>
+                <div class="grid cols-2">
+                  <label for="validFrom">
+                    Ingangsdatum tarief
+                    <input id="validFrom" name="validFrom" type="date" .value=${this.validFromDate} @input=${(e: InputEvent) => (this.validFromDate = (e.target as HTMLInputElement).value)} />
+                  </label>
+                  <label for="obligationLabel">
+                    Omschrijving verplichting
+                    <input id="obligationLabel" name="obligationLabel" .value=${this.obligationLabel} @input=${(e: InputEvent) => (this.obligationLabel = (e.target as HTMLInputElement).value)} />
+                  </label>
+                </div>
+                <label for="description">
+                  Omschrijving
+                  <textarea id="description" name="description" .value=${this.description} @input=${(e: InputEvent) => (this.description = (e.target as HTMLTextAreaElement).value)} rows="3"></textarea>
+                </label>
+              </fieldset>
+
+              <fieldset>
+                <legend>Betaling</legend>
+                <div class="grid cols-2">
+                  <label for="scheduleType">
+                    Schema
+                    <select id="scheduleType" name="scheduleType" .value=${this.scheduleType} @change=${(e: Event) => (this.scheduleType = (e.target as HTMLSelectElement).value as 'recurring' | 'installments')}>
+                      <option value="recurring">Terugkerend</option>
+                      <option value="installments">Termijnen</option>
+                    </select>
+                  </label>
+                </div>
+                ${this.scheduleType === 'recurring' ? html`
+                  <div class="grid cols-2">
+                    <label for="amount">
+                      Bedrag (€)
+                      <input id="amount" name="amount" type="number" min="0" step="0.01" .value=${this.amount} @input=${(e: InputEvent) => (this.amount = (e.target as HTMLInputElement).value)} />
+                    </label>
+                    <label for="frequency">
+                      Frequentie
+                      <select id="frequency" name="frequency" .value=${this.frequency} @change=${(e: Event) => (this.frequency = (e.target as HTMLSelectElement).value as PaymentFrequency)}>
+                        <option value="daily">Dagelijks</option>
+                        <option value="weekly">Wekelijks</option>
+                        <option value="biweekly">Tweewekelijks</option>
+                        <option value="monthly">Maandelijks</option>
+                        <option value="quarterly">Per kwartaal</option>
+                        <option value="yearly">Jaarlijks</option>
+                      </select>
+                    </label>
+                  </div>
+                ` : html`
+                  <div class="grid cols-2">
+                    <label for="termsCount">
+                      Aantal termijnen
+                      <input id="termsCount" name="termsCount" type="number" min="0" step="1" .value=${this.termsCount} @input=${(e: InputEvent) => {
+                        const v = (e.target as HTMLInputElement).value;
+                        this.termsCount = v;
+                        const n = Math.max(0, Number(v) || 0);
+                        if (n > this.installments.length) {
+                          this.installments = [...this.installments, ...Array.from({ length: n - this.installments.length }, () => ({ date: '', amount: '' }))];
+                        } else if (n < this.installments.length) {
+                          this.installments = this.installments.slice(0, n);
+                        }
+                      }} />
+                    </label>
+                  </div>
+                  ${Number(this.termsCount) > 0 ? html`
+                    <div class="grid">
+                      ${this.installments.slice(0, Number(this.termsCount)).map((t, idx) => html`
+                        <div class="grid cols-2" style="align-items:end;">
+                          <label>
+                            Datum
+                            <input type="date" .value=${t.date} @input=${(e: InputEvent) => {
+                              const v = (e.target as HTMLInputElement).value; this.installments = this.installments.map((it, i) => i === idx ? { ...it, date: v } : it);
+                            }} />
+                          </label>
+                          <label>
+                            Bedrag (€)
+                            <input type="number" min="0" step="0.01" .value=${t.amount} @input=${(e: InputEvent) => {
+                              const v = (e.target as HTMLInputElement).value; this.installments = this.installments.map((it, i) => i === idx ? { ...it, amount: v } : it);
+                            }} />
+                          </label>
+                        </div>
+                      `)}
+                    </div>
+                  ` : null}
+                `}
+              </fieldset>
+
+              <div class="actions">
+                <button type="button" class="btn" @click=${this.close}>Annuleren</button>
+                <button type="submit" class="btn primary">Opslaan</button>
+              </div>
+            </form>
+          </div>
         </div>
       </div>
     `;

--- a/frontend/src/components/contract-form.ts
+++ b/frontend/src/components/contract-form.ts
@@ -1,6 +1,6 @@
 import { LitElement, html, css } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import type { NewContractInput, PaymentFrequency } from '../types';
+import type { NewContractInput, PaymentFrequency, PaymentScheduleInput } from '../types';
 
 @customElement('contract-form')
 export class ContractForm extends LitElement {
@@ -19,14 +19,35 @@ export class ContractForm extends LitElement {
   @state() private amount: string = '';
   @state() private obligationLabel: string = '';
   @state() private frequency: PaymentFrequency = 'monthly';
+  @state() private scheduleType: 'recurring' | 'installments' = 'recurring';
+  @state() private termsCount: string = '0';
+  @state() private installments: { date: string; amount: string }[] = [];
 
   private onSubmit(e: Event) {
     e.preventDefault();
+    // Build rate depending on schedule type
+    let rate: { amount: number; frequency?: PaymentFrequency; schedule?: PaymentScheduleInput } | undefined;
+    if (this.amount.trim() !== '' && this.scheduleType === 'recurring') {
+      rate = { amount: Number(this.amount), frequency: this.frequency, schedule: { type: 'recurring', frequency: this.frequency } };
+    } else if (this.scheduleType === 'installments') {
+      const count = Number(this.termsCount) || 0;
+      const filled = this.installments.slice(0, count).filter(t => t.date && t.amount.trim() !== '');
+      if (count > 0 && filled.length !== count) {
+        this.dispatchEvent(new CustomEvent('form-error', { detail: 'Vul alle termijnen met datum en bedrag in.' }));
+        return;
+      }
+      const installments = filled.map(t => ({ date: t.date, amount: Number(t.amount) }));
+      const total = installments.reduce((s, i) => s + (isFinite(i.amount) ? i.amount : 0), 0);
+      if (count > 0) {
+        rate = { amount: total, schedule: { type: 'installments', installments } };
+      }
+    }
+
     const input: NewContractInput = {
       name: this.name.trim(),
       accountNumber: this.accountNumber.trim(),
       description: this.description.trim() || undefined,
-      obligations: this.amount.trim() !== '' ? [{ label: this.obligationLabel.trim() || undefined, rate: { amount: Number(this.amount), frequency: this.frequency } }] : undefined,
+      obligations: rate ? [{ label: this.obligationLabel.trim() || undefined, rate }] : undefined,
     };
     if (!input.name || !input.accountNumber) {
       // Basic validation
@@ -41,6 +62,9 @@ export class ContractForm extends LitElement {
   this.amount = '';
   this.obligationLabel = '';
   this.frequency = 'monthly';
+  this.scheduleType = 'recurring';
+  this.termsCount = '0';
+  this.installments = [];
     // Clear input elements synchronously so tests that read value immediately after submit see empty strings
     const nameEl = this.shadowRoot?.querySelector('input[name="name"]') as HTMLInputElement | null;
     const accEl = this.shadowRoot?.querySelector('input[name="accountNumber"]') as HTMLInputElement | null;
@@ -54,6 +78,10 @@ export class ContractForm extends LitElement {
   if (olabEl) olabEl.value = '';
   const freqEl = this.shadowRoot?.querySelector('select[name="frequency"]') as HTMLSelectElement | null;
   if (freqEl) freqEl.value = 'monthly';
+  const schedEl = this.shadowRoot?.querySelector('select[name="scheduleType"]') as HTMLSelectElement | null;
+  if (schedEl) schedEl.value = 'recurring';
+  const countEl = this.shadowRoot?.querySelector('input[name="termsCount"]') as HTMLInputElement | null;
+  if (countEl) countEl.value = '0';
   }
 
   render() {
@@ -69,20 +97,63 @@ export class ContractForm extends LitElement {
             <input name="accountNumber" .value=${this.accountNumber} @input=${(e: InputEvent) => (this.accountNumber = (e.target as HTMLInputElement).value)} placeholder="IBAN" required />
           </label>
           <label>
-            Bedrag (€)
-            <input name="amount" type="number" min="0" step="0.01" .value=${this.amount} @input=${(e: InputEvent) => (this.amount = (e.target as HTMLInputElement).value)} placeholder="0,00" />
-          </label>
-          <label>
-            Frequentie
-            <select name="frequency" .value=${this.frequency} @change=${(e: Event) => (this.frequency = (e.target as HTMLSelectElement).value as PaymentFrequency)}>
-              <option value="daily">Dagelijks</option>
-              <option value="weekly">Wekelijks</option>
-              <option value="biweekly">Tweewekelijks</option>
-              <option value="monthly">Maandelijks</option>
-              <option value="quarterly">Per kwartaal</option>
-              <option value="yearly">Jaarlijks</option>
+            Schema
+            <select name="scheduleType" .value=${this.scheduleType} @change=${(e: Event) => (this.scheduleType = (e.target as HTMLSelectElement).value as 'recurring' | 'installments')}>
+              <option value="recurring">Terugkerend</option>
+              <option value="installments">Termijnen</option>
             </select>
           </label>
+          ${this.scheduleType === 'recurring' ? html`
+            <label>
+              Bedrag (€ per periode)
+              <input name="amount" type="number" min="0" step="0.01" .value=${this.amount} @input=${(e: InputEvent) => (this.amount = (e.target as HTMLInputElement).value)} placeholder="0,00" />
+            </label>
+            <label>
+              Frequentie
+              <select name="frequency" .value=${this.frequency} @change=${(e: Event) => (this.frequency = (e.target as HTMLSelectElement).value as PaymentFrequency)}>
+                <option value="daily">Dagelijks</option>
+                <option value="weekly">Wekelijks</option>
+                <option value="biweekly">Tweewekelijks</option>
+                <option value="monthly">Maandelijks</option>
+                <option value="quarterly">Per kwartaal</option>
+                <option value="yearly">Jaarlijks</option>
+              </select>
+            </label>
+          ` : html`
+            <label>
+              Aantal termijnen
+              <input name="termsCount" type="number" min="0" step="1" .value=${this.termsCount} @input=${(e: InputEvent) => {
+                const v = (e.target as HTMLInputElement).value;
+                this.termsCount = v;
+                const n = Math.max(0, Number(v) || 0);
+                if (n > this.installments.length) {
+                  this.installments = [...this.installments, ...Array.from({ length: n - this.installments.length }, () => ({ date: '', amount: '' }))];
+                } else if (n < this.installments.length) {
+                  this.installments = this.installments.slice(0, n);
+                }
+              }} />
+            </label>
+            ${Number(this.termsCount) > 0 ? html`
+              <div style="grid-column: 1 / -1; display: grid; gap: .5rem;">
+                ${this.installments.slice(0, Number(this.termsCount)).map((t, idx) => html`
+                  <div class="row" style="align-items:end;">
+                    <label>
+                      Datum
+                      <input type="date" .value=${t.date} @input=${(e: InputEvent) => {
+                        const v = (e.target as HTMLInputElement).value; this.installments = this.installments.map((it, i) => i === idx ? { ...it, date: v } : it);
+                      }} />
+                    </label>
+                    <label>
+                      Bedrag (€)
+                      <input type="number" min="0" step="0.01" .value=${t.amount} @input=${(e: InputEvent) => {
+                        const v = (e.target as HTMLInputElement).value; this.installments = this.installments.map((it, i) => i === idx ? { ...it, amount: v } : it);
+                      }} />
+                    </label>
+                  </div>
+                `)}
+              </div>
+            ` : null}
+          `}
           <label>
             Omschrijving verplichting
             <input name="obligationLabel" .value=${this.obligationLabel} @input=${(e: InputEvent) => (this.obligationLabel = (e.target as HTMLInputElement).value)} placeholder="Bijv. Huur per maand" />

--- a/frontend/src/components/contract-form.ts
+++ b/frontend/src/components/contract-form.ts
@@ -1,21 +1,24 @@
 import { LitElement, html, css } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import type { NewContractInput } from '../types';
+import type { NewContractInput, PaymentFrequency } from '../types';
 
 @customElement('contract-form')
 export class ContractForm extends LitElement {
   static styles = css`
-    form { display: grid; gap: 0.5rem; max-width: 480px; }
-    label { display: grid; gap: 0.25rem; font-weight: 600; }
-    input, textarea { padding: 0.5rem; font: inherit; }
-    button { padding: 0.6rem 1rem; font: inherit; cursor: pointer; }
-    .row { display: flex; gap: 0.5rem; }
-    .row > * { flex: 1; }
+  form { display: grid; gap: 0.75rem; width: 100%; max-width: 560px; }
+  label { display: grid; gap: 0.25rem; font-weight: 600; }
+  input, textarea, select { padding: 0.6rem; font: inherit; width: 100%; box-sizing: border-box; }
+  button { padding: 0.7rem 1rem; font: inherit; cursor: pointer; width: 100%; }
+  .row { display: grid; grid-template-columns: 1fr; gap: 0.5rem; }
+  @media (min-width: 640px) { .row { grid-template-columns: 1fr 1fr; } }
   `;
 
   @state() private name = '';
   @state() private accountNumber = '';
   @state() private description = '';
+  @state() private amount: string = '';
+  @state() private obligationLabel: string = '';
+  @state() private frequency: PaymentFrequency = 'monthly';
 
   private onSubmit(e: Event) {
     e.preventDefault();
@@ -23,6 +26,7 @@ export class ContractForm extends LitElement {
       name: this.name.trim(),
       accountNumber: this.accountNumber.trim(),
       description: this.description.trim() || undefined,
+      obligations: this.amount.trim() !== '' ? [{ label: this.obligationLabel.trim() || undefined, rate: { amount: Number(this.amount), frequency: this.frequency } }] : undefined,
     };
     if (!input.name || !input.accountNumber) {
       // Basic validation
@@ -34,13 +38,22 @@ export class ContractForm extends LitElement {
     this.name = '';
     this.accountNumber = '';
     this.description = '';
+  this.amount = '';
+  this.obligationLabel = '';
+  this.frequency = 'monthly';
     // Clear input elements synchronously so tests that read value immediately after submit see empty strings
     const nameEl = this.shadowRoot?.querySelector('input[name="name"]') as HTMLInputElement | null;
     const accEl = this.shadowRoot?.querySelector('input[name="accountNumber"]') as HTMLInputElement | null;
     const descEl = this.shadowRoot?.querySelector('textarea[name="description"]') as HTMLTextAreaElement | null;
+  const amountEl = this.shadowRoot?.querySelector('input[name="amount"]') as HTMLInputElement | null;
+  const olabEl = this.shadowRoot?.querySelector('input[name="obligationLabel"]') as HTMLInputElement | null;
     if (nameEl) nameEl.value = '';
     if (accEl) accEl.value = '';
     if (descEl) descEl.value = '';
+  if (amountEl) amountEl.value = '';
+  if (olabEl) olabEl.value = '';
+  const freqEl = this.shadowRoot?.querySelector('select[name="frequency"]') as HTMLSelectElement | null;
+  if (freqEl) freqEl.value = 'monthly';
   }
 
   render() {
@@ -54,6 +67,25 @@ export class ContractForm extends LitElement {
           <label>
             Rekeningnummer
             <input name="accountNumber" .value=${this.accountNumber} @input=${(e: InputEvent) => (this.accountNumber = (e.target as HTMLInputElement).value)} placeholder="IBAN" required />
+          </label>
+          <label>
+            Bedrag (€)
+            <input name="amount" type="number" min="0" step="0.01" .value=${this.amount} @input=${(e: InputEvent) => (this.amount = (e.target as HTMLInputElement).value)} placeholder="0,00" />
+          </label>
+          <label>
+            Frequentie
+            <select name="frequency" .value=${this.frequency} @change=${(e: Event) => (this.frequency = (e.target as HTMLSelectElement).value as PaymentFrequency)}>
+              <option value="daily">Dagelijks</option>
+              <option value="weekly">Wekelijks</option>
+              <option value="biweekly">Tweewekelijks</option>
+              <option value="monthly">Maandelijks</option>
+              <option value="quarterly">Per kwartaal</option>
+              <option value="yearly">Jaarlijks</option>
+            </select>
+          </label>
+          <label>
+            Omschrijving verplichting
+            <input name="obligationLabel" .value=${this.obligationLabel} @input=${(e: InputEvent) => (this.obligationLabel = (e.target as HTMLInputElement).value)} placeholder="Bijv. Huur per maand" />
           </label>
         </div>
         <label>

--- a/frontend/src/components/contract-list.ts
+++ b/frontend/src/components/contract-list.ts
@@ -27,6 +27,16 @@ export class ContractList extends LitElement {
               <div>
                 <div class="name">${c.name}</div>
                 <div class="meta">Rekening: ${c.accountNumber}</div>
+                ${Array.isArray(c.obligations) && c.obligations.length ? html`<div class="meta">Totaal verplichtingen: € ${c.obligations.reduce((sum, ob) => {
+                  const now = Date.now();
+                  const current = (ob.rates ?? []).filter(r => (!r.validFrom || Date.parse(r.validFrom) <= now) && (!r.validTo || Date.parse(r.validTo) >= now)).slice(-1)[0];
+                  return sum + (current ? current.amount : 0);
+                }, 0).toFixed(2)} ${(() => {
+                  // If all current rates share the same frequency, display it; else omit.
+                  const now = Date.now();
+                  const freqs = new Set((c.obligations ?? []).map(ob => (ob.rates ?? []).filter(r => (!r.validFrom || Date.parse(r.validFrom) <= now) && (!r.validTo || Date.parse(r.validTo) >= now)).slice(-1)[0]?.frequency ?? 'monthly'));
+                  return freqs.size === 1 ? `(${[...freqs][0]})` : '';
+                })()}</div>` : null}
               </div>
               <div>
                 <button @click=${() => this.dispatchEvent(new CustomEvent('edit-request', { detail: c.id, bubbles: true, composed: true }))} aria-label="Bewerk ${c.name}">Bewerken</button>

--- a/frontend/src/components/contract-list.ts
+++ b/frontend/src/components/contract-list.ts
@@ -29,14 +29,29 @@ export class ContractList extends LitElement {
                 <div class="meta">Rekening: ${c.accountNumber}</div>
                 ${Array.isArray(c.obligations) && c.obligations.length ? (() => {
                   const now = Date.now();
-                  const currents = ((c.obligations ?? []).map(ob => (ob.rates ?? []).filter(r => (!r.validFrom || Date.parse(r.validFrom) <= now) && (!r.validTo || Date.parse(r.validTo) >= now)).slice(-1)[0]).filter(Boolean) as PaymentRate[]);
+                  const pickDisplayRate = (rates: PaymentRate[]): PaymentRate | undefined => {
+                    if (!rates?.length) return undefined;
+                    const actives = rates.filter(r => (!r.validFrom || Date.parse(r.validFrom) <= now) && (!r.validTo || Date.parse(r.validTo) >= now));
+                    if (actives.length) {
+                      // Latest active by validFrom else createdAt
+                      return actives.sort((a, b) => (Date.parse(a.validFrom ?? a.createdAt) - Date.parse(b.validFrom ?? b.createdAt)))[actives.length - 1];
+                    }
+                    // Fallback: most recent by validFrom or createdAt
+                    return [...rates].sort((a, b) => (Date.parse(b.validFrom ?? b.createdAt) - Date.parse(a.validFrom ?? a.createdAt)))[0];
+                  };
+                  const entries = (c.obligations ?? []).map(ob => ({ ob, rate: pickDisplayRate(ob.rates ?? []) }));
+                  const currents = (entries.map(e => e.rate).filter(Boolean) as PaymentRate[]);
                   type Rec = { amount: number; frequency: 'daily'|'weekly'|'biweekly'|'monthly'|'quarterly'|'yearly' };
                   const recurring: Rec[] = [];
+                  let unknownRecurringTotalFromRates = 0;
                   for (const r of currents) {
                     if (r.schedule?.type === 'recurring') {
                       recurring.push({ amount: r.amount || 0, frequency: r.schedule.frequency });
                     } else if (!r.schedule && r.frequency) {
                       recurring.push({ amount: r.amount || 0, frequency: r.frequency });
+                    } else if (!r.schedule && !r.frequency) {
+                      // Legacy with no frequency: still show amount under unknown bucket
+                      unknownRecurringTotalFromRates += r.amount || 0;
                     }
                   }
                   const installments = currents.flatMap(r => r.schedule?.type === 'installments' ? [{ amount: r.amount || 0, count: r.schedule.installments.length }] : []);
@@ -49,10 +64,47 @@ export class ContractList extends LitElement {
                     quarterly: 'kwartaal',
                     yearly: 'jaar',
                   } as const)[f];
+                  const inferFreqFromText = (txt?: string): Rec['frequency'] | undefined => {
+                    if (!txt) return undefined;
+                    const t = txt.toLowerCase();
+                    if (/biweekly|twee\s*wekelijks|2\s*-?\s*weken/.test(t)) return 'biweekly';
+                    if (/dag|dagelijks/.test(t)) return 'daily';
+                    if (/week|wekelijks/.test(t)) return 'weekly';
+                    if (/maand|maandelijks/.test(t)) return 'monthly';
+                    if (/kwartaal|per\s*kwartaal/.test(t)) return 'quarterly';
+                    if (/jaar|jaarlijks|per\s*jaar/.test(t)) return 'yearly';
+                    return undefined;
+                  };
 
                   const byFreq = new Map<Rec['frequency'], number>();
+                  let unknownRecurringTotal = unknownRecurringTotalFromRates;
                   for (const r of recurring) {
                     byFreq.set(r.frequency, (byFreq.get(r.frequency) ?? 0) + r.amount);
+                  }
+                  // If rates existed but lacked frequency, try to read legacy frequency from the obligation
+                  for (const { ob, rate } of entries) {
+                    if (!rate) continue;
+                    const hasKnown = Boolean(rate.schedule?.type === 'recurring' || rate.frequency);
+                    if (hasKnown) continue;
+                    const legacyFreq = (ob as unknown as { frequency?: Rec['frequency']; label?: string })?.frequency
+                      ?? inferFreqFromText((ob as unknown as { label?: string })?.label);
+                    if (legacyFreq) {
+                      byFreq.set(legacyFreq, (byFreq.get(legacyFreq) ?? 0) + (rate.amount || 0));
+                      unknownRecurringTotal -= (rate.amount || 0);
+                    }
+                  }
+                  // Legacy fallback: only if an obligation has no selected rate
+                  for (const { ob, rate } of entries) {
+                    if (rate) continue;
+                    const legacy = ob as unknown as { amount?: number; frequency?: Rec['frequency'] };
+                    const legacyAmount = typeof legacy?.amount === 'number' && isFinite(legacy.amount) ? legacy.amount : 0;
+                    if (legacyAmount > 0) {
+                      if (legacy?.frequency) {
+                        byFreq.set(legacy.frequency, (byFreq.get(legacy.frequency) ?? 0) + legacyAmount);
+                      } else {
+                        unknownRecurringTotal += legacyAmount;
+                      }
+                    }
                   }
                   const uniqueFreqs = [...byFreq.keys()];
                   const recurringNode = uniqueFreqs.length > 0 ? html`
@@ -61,7 +113,8 @@ export class ContractList extends LitElement {
                     ` : html`
                       <div class="meta">Doorlopend: ${uniqueFreqs.map(f => `€ ${(byFreq.get(f) ?? 0).toFixed(2)} per ${freqLabel(f)}`).join(' + ')}</div>
                     `}
-                  ` : null;
+                    ${unknownRecurringTotal > 0 ? html`<div class="meta">Doorlopend: € ${unknownRecurringTotal.toFixed(2)}</div>` : null}
+                  ` : (unknownRecurringTotal > 0 ? html`<div class="meta">Doorlopend: € ${unknownRecurringTotal.toFixed(2)}</div>` : null);
 
                   const installmentsNode = installments.length > 0 ? html`
                     <div class="meta">Termijnen: € ${installments.reduce((s, i) => s + i.amount, 0).toFixed(2)} (${installments.reduce((s, i) => s + i.count, 0)} termijnen)</div>

--- a/frontend/src/storage/contractsRepository.ts
+++ b/frontend/src/storage/contractsRepository.ts
@@ -42,6 +42,8 @@ class MemoryContractRepository implements ContractRepository {
             validFrom: input.rate.validFrom ?? now,
             validTo: input.rate.validTo,
             createdAt: now,
+            schedule: input.rate.schedule,
+            frequency: input.rate.frequency,
           };
           target.rates = [...(target.rates ?? []), rate];
         }
@@ -50,7 +52,7 @@ class MemoryContractRepository implements ContractRepository {
           id: uuid(),
           label: input.label,
           createdAt: now,
-          rates: input.rate ? [{ id: uuid(), amount: input.rate.amount, validFrom: input.rate.validFrom ?? now, validTo: input.rate.validTo, createdAt: now }] : [],
+          rates: input.rate ? [{ id: uuid(), amount: input.rate.amount, validFrom: input.rate.validFrom ?? now, validTo: input.rate.validTo, createdAt: now, schedule: input.rate.schedule, frequency: input.rate.frequency }] : [],
         };
         result.push(newOb);
       }
@@ -155,6 +157,8 @@ class IDBContractRepository implements ContractRepository {
             validFrom: input.rate.validFrom ?? now,
             validTo: input.rate.validTo,
             createdAt: now,
+            schedule: input.rate.schedule,
+            frequency: input.rate.frequency,
           };
           target.rates = [...(target.rates ?? []), rate];
         }
@@ -163,7 +167,7 @@ class IDBContractRepository implements ContractRepository {
           id: uuid(),
           label: input.label,
           createdAt: now,
-          rates: input.rate ? [{ id: uuid(), amount: input.rate.amount, validFrom: input.rate.validFrom ?? now, validTo: input.rate.validTo, createdAt: now }] : [],
+          rates: input.rate ? [{ id: uuid(), amount: input.rate.amount, validFrom: input.rate.validFrom ?? now, validTo: input.rate.validTo, createdAt: now, schedule: input.rate.schedule, frequency: input.rate.frequency }] : [],
         };
         result.push(newOb);
       }

--- a/frontend/src/storage/contractsRepository.ts
+++ b/frontend/src/storage/contractsRepository.ts
@@ -1,4 +1,4 @@
-import type { Contract, NewContractInput, UUID } from '../types';
+import type { Contract, NewContractInput, PaymentObligation, PaymentObligationInput, PaymentRate, UUID } from '../types';
 
 export type RepoBackend = 'auto' | 'memory' | 'idb';
 
@@ -24,12 +24,47 @@ function uuid(): UUID {
 class MemoryContractRepository implements ContractRepository {
   private store = new Map<UUID, Contract>();
 
+  private mapObligationsAppendOnly(inputs?: PaymentObligationInput[], existing?: PaymentObligation[]): PaymentObligation[] | undefined {
+    if (!inputs) return existing;
+    const now = new Date().toISOString();
+    const byId = new Map<string, PaymentObligation>();
+    existing?.forEach(o => byId.set(o.id, { ...o, rates: [...(o.rates ?? [])] }));
+    const result: PaymentObligation[] = existing ? Array.from(byId.values()) : [];
+
+    for (const input of inputs) {
+      if (input.id && byId.has(input.id)) {
+        const target = result.find(o => o.id === input.id)!;
+        if (input.label !== undefined) target.label = input.label;
+        if (input.rate) {
+          const rate: PaymentRate = {
+            id: uuid(),
+            amount: input.rate.amount,
+            validFrom: input.rate.validFrom ?? now,
+            validTo: input.rate.validTo,
+            createdAt: now,
+          };
+          target.rates = [...(target.rates ?? []), rate];
+        }
+      } else {
+        const newOb: PaymentObligation = {
+          id: uuid(),
+          label: input.label,
+          createdAt: now,
+          rates: input.rate ? [{ id: uuid(), amount: input.rate.amount, validFrom: input.rate.validFrom ?? now, validTo: input.rate.validTo, createdAt: now }] : [],
+        };
+        result.push(newOb);
+      }
+    }
+    return result;
+  }
+
   async add(input: NewContractInput): Promise<Contract> {
     const c: Contract = {
       id: uuid(),
       name: input.name.trim(),
       accountNumber: input.accountNumber.trim(),
       description: input.description?.trim() || undefined,
+  obligations: this.mapObligationsAppendOnly(input.obligations),
       createdAt: new Date().toISOString(),
     };
     this.store.set(c.id, c);
@@ -51,7 +86,8 @@ class MemoryContractRepository implements ContractRepository {
       ...existing,
       name: input.name.trim(),
       accountNumber: input.accountNumber.trim(),
-      description: input.description?.trim() || undefined,
+  description: input.description?.trim() || undefined,
+  obligations: this.mapObligationsAppendOnly(input.obligations, existing.obligations),
     };
     this.store.set(id, updated);
     return updated;
@@ -101,12 +137,47 @@ class IDBContractRepository implements ContractRepository {
     });
   }
 
+  private mapObligationsAppendOnly(inputs?: PaymentObligationInput[], existing?: PaymentObligation[]): PaymentObligation[] | undefined {
+    if (!inputs) return existing;
+    const now = new Date().toISOString();
+    const byId = new Map<string, PaymentObligation>();
+    existing?.forEach(o => byId.set(o.id, { ...o, rates: [...(o.rates ?? [])] }));
+    const result: PaymentObligation[] = existing ? Array.from(byId.values()) : [];
+
+    for (const input of inputs) {
+      if (input.id && byId.has(input.id)) {
+        const target = result.find(o => o.id === input.id)!;
+        if (input.label !== undefined) target.label = input.label;
+        if (input.rate) {
+          const rate: PaymentRate = {
+            id: uuid(),
+            amount: input.rate.amount,
+            validFrom: input.rate.validFrom ?? now,
+            validTo: input.rate.validTo,
+            createdAt: now,
+          };
+          target.rates = [...(target.rates ?? []), rate];
+        }
+      } else {
+        const newOb: PaymentObligation = {
+          id: uuid(),
+          label: input.label,
+          createdAt: now,
+          rates: input.rate ? [{ id: uuid(), amount: input.rate.amount, validFrom: input.rate.validFrom ?? now, validTo: input.rate.validTo, createdAt: now }] : [],
+        };
+        result.push(newOb);
+      }
+    }
+    return result;
+  }
+
   async add(input: NewContractInput): Promise<Contract> {
     const c: Contract = {
       id: uuid(),
       name: input.name.trim(),
       accountNumber: input.accountNumber.trim(),
       description: input.description?.trim() || undefined,
+  obligations: this.mapObligationsAppendOnly(input.obligations),
       createdAt: new Date().toISOString(),
     };
     await this.tx<void>('readwrite', (store) => {
@@ -147,7 +218,8 @@ class IDBContractRepository implements ContractRepository {
       ...existing,
       name: input.name.trim(),
       accountNumber: input.accountNumber.trim(),
-      description: input.description?.trim() || undefined,
+  description: input.description?.trim() || undefined,
+  obligations: this.mapObligationsAppendOnly(input.obligations, existing.obligations),
     };
     await this.tx<void>('readwrite', (store) => {
       store.put(updated);

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -7,6 +7,8 @@ export interface Contract {
   name: string;
   accountNumber: string; // IBAN or other
   description?: string;
+  // Payment obligations associated with this contract (append-only rates)
+  obligations?: PaymentObligation[];
   createdAt: string; // ISO string
 }
 
@@ -14,4 +16,44 @@ export interface NewContractInput {
   name: string;
   accountNumber: string;
   description?: string;
+  // Provide zero or more obligations when creating or updating
+  obligations?: PaymentObligationInput[];
 }
+
+export interface PaymentRate {
+  id: UUID;
+  amount: number; // EUR amount for the obligation
+  validFrom: string; // ISO timestamp
+  validTo?: string; // ISO timestamp
+  createdAt: string; // ISO timestamp
+  frequency?: PaymentFrequency; // how often this amount recurs
+}
+
+export interface PaymentObligation {
+  id: UUID;
+  label?: string;
+  createdAt: string; // ISO timestamp
+  rates: PaymentRate[];
+}
+
+export interface PaymentRateInput {
+  id?: UUID; // if provided, may target an existing rate (not typical in append-only)
+  amount: number;
+  validFrom?: string; // default: now
+  validTo?: string;   // usually omitted for current rate
+  frequency?: PaymentFrequency;
+}
+
+export interface PaymentObligationInput {
+  id?: UUID; // present when updating an existing obligation
+  label?: string;
+  rate?: PaymentRateInput; // provide one new rate per update/create
+}
+
+export type PaymentFrequency =
+  | 'daily'
+  | 'weekly'
+  | 'biweekly'
+  | 'monthly'
+  | 'quarterly'
+  | 'yearly';

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -22,11 +22,13 @@ export interface NewContractInput {
 
 export interface PaymentRate {
   id: UUID;
-  amount: number; // EUR amount for the obligation
+  amount: number; // EUR amount; for recurring it's per period, for installments it's the sum of all installments
   validFrom: string; // ISO timestamp
   validTo?: string; // ISO timestamp
   createdAt: string; // ISO timestamp
-  frequency?: PaymentFrequency; // how often this amount recurs
+  // Preferred scheduling model. If omitted, legacy `frequency` may be used.
+  schedule?: PaymentSchedule;
+  frequency?: PaymentFrequency; // legacy: how often this amount recurs
 }
 
 export interface PaymentObligation {
@@ -41,6 +43,8 @@ export interface PaymentRateInput {
   amount: number;
   validFrom?: string; // default: now
   validTo?: string;   // usually omitted for current rate
+  // Preferred: provide a schedule. If omitted, `frequency` may be used for recurring.
+  schedule?: PaymentScheduleInput;
   frequency?: PaymentFrequency;
 }
 
@@ -57,3 +61,26 @@ export type PaymentFrequency =
   | 'monthly'
   | 'quarterly'
   | 'yearly';
+
+// Scheduling
+export interface RecurringSchedule {
+  type: 'recurring';
+  frequency: PaymentFrequency;
+}
+
+export interface InstallmentTerm {
+  id?: UUID;
+  date: string; // ISO date (YYYY-MM-DD) or full timestamp
+  amount: number; // EUR amount for this term
+}
+
+export interface InstallmentsSchedule {
+  type: 'installments';
+  installments: InstallmentTerm[]; // explicit schedule
+}
+
+export type PaymentSchedule = RecurringSchedule | InstallmentsSchedule;
+
+export type PaymentScheduleInput =
+  | { type: 'recurring'; frequency: PaymentFrequency }
+  | { type: 'installments'; installments: { date: string; amount: number }[] };

--- a/frontend/tests/contractEdit.test.ts
+++ b/frontend/tests/contractEdit.test.ts
@@ -5,24 +5,30 @@ function nextFrame() { return new Promise((r) => requestAnimationFrame(() => r(n
 
 describe('contract-edit', () => {
   it('opens with contract values and emits save with updates', async () => {
-  const el = document.createElement('contract-edit') as HTMLElement & { open: boolean; contract?: { id: string; name: string; accountNumber: string; createdAt: string; description?: string } };
+  const el = document.createElement('contract-edit') as HTMLElement & { open: boolean; contract?: { id: string; name: string; accountNumber: string; createdAt: string; description?: string; obligations?: { id: string; label?: string; rates?: { id: string; amount: number; validFrom: string }[] }[] } };
     document.body.appendChild(el);
     el.open = true;
-    el.contract = { id: '1', name: 'Huur', accountNumber: 'NL00', createdAt: new Date().toISOString() };
+  el.contract = { id: '1', name: 'Huur', accountNumber: 'NL00', createdAt: new Date().toISOString(), obligations: [{ id: 'o1', label: 'Huur', rates: [{ id: 'r1', amount: 1200, validFrom: new Date().toISOString() }] }] };
     await nextFrame();
 
     const root = el.shadowRoot!;
     const name = root.querySelector('input[name="name"]') as HTMLInputElement;
-    const acc = root.querySelector('input[name="accountNumber"]') as HTMLInputElement;
+  const acc = root.querySelector('input[name="accountNumber"]') as HTMLInputElement;
+  const amount = root.querySelector('input[name="amount"]') as HTMLInputElement;
+  const olab = root.querySelector('input[name="obligationLabel"]') as HTMLInputElement;
 
     expect(name.value).toBe('Huur');
-    expect(acc.value).toBe('NL00');
+  expect(acc.value).toBe('NL00');
+  expect(amount.value).toBe('1200');
+  expect(olab.value).toBe('Huur');
 
     name.value = 'Huur nieuw'; name.dispatchEvent(new Event('input'));
 
-  const evPromise = new Promise<CustomEvent<{ id: string; input: { name: string } }>>((resolve) => el.addEventListener('contract-save', (e) => resolve(e as CustomEvent<{ id: string; input: { name: string } }>)));
+  const evPromise = new Promise<CustomEvent<{ id: string; input: { name: string; obligations?: { rate?: { amount: number }; label?: string }[] } }>>((resolve) => el.addEventListener('contract-save', (e) => resolve(e as CustomEvent<{ id: string; input: { name: string; obligations?: { rate?: { amount: number }; label?: string }[] } }>)));
     (root.querySelector('form') as HTMLFormElement).dispatchEvent(new Event('submit', { cancelable: true, bubbles: true }));
     const ev = await evPromise;
     expect(ev.detail.input.name).toBe('Huur nieuw');
+  expect(ev.detail.input.obligations?.[0].rate?.amount).toBe(1200);
+    expect(ev.detail.input.obligations?.[0].label).toBe('Huur');
   });
 });

--- a/frontend/tests/contractEdit.test.ts
+++ b/frontend/tests/contractEdit.test.ts
@@ -37,4 +37,21 @@ describe('contract-edit', () => {
   expect(ev.detail.input.obligations?.[0].rate?.frequency).toBe('weekly');
     expect(ev.detail.input.obligations?.[0].label).toBe('Huur');
   });
+
+  it('renders an accessible dialog structure', async () => {
+    const el = document.createElement('contract-edit') as HTMLElement & { open: boolean; contract?: { id: string; name: string; accountNumber: string; createdAt: string; obligations?: { id: string; label?: string; rates?: { id: string; amount: number; validFrom: string }[] }[] } };
+    document.body.appendChild(el);
+    el.open = true;
+    el.contract = { id: '1', name: 'Huur', accountNumber: 'NL00', createdAt: new Date().toISOString(), obligations: [{ id: 'o1', label: 'Huur', rates: [{ id: 'r1', amount: 1200, validFrom: new Date().toISOString() }] }] };
+    await nextFrame();
+
+    const root = el.shadowRoot!;
+    const dialog = root.querySelector('[role="dialog"]') as HTMLElement;
+    expect(dialog).toBeTruthy();
+    expect(dialog.getAttribute('aria-modal')).toBe('true');
+    const title = root.querySelector('#edit-title');
+    expect(title?.textContent).toContain('Contract bewerken');
+    const closeBtn = root.querySelector('button[aria-label="Sluiten"]');
+    expect(closeBtn).toBeTruthy();
+  });
 });

--- a/frontend/tests/contractEdit.test.ts
+++ b/frontend/tests/contractEdit.test.ts
@@ -24,11 +24,17 @@ describe('contract-edit', () => {
 
     name.value = 'Huur nieuw'; name.dispatchEvent(new Event('input'));
 
-  const evPromise = new Promise<CustomEvent<{ id: string; input: { name: string; obligations?: { rate?: { amount: number }; label?: string }[] } }>>((resolve) => el.addEventListener('contract-save', (e) => resolve(e as CustomEvent<{ id: string; input: { name: string; obligations?: { rate?: { amount: number }; label?: string }[] } }>)));
+  // Change frequency as part of the edit
+  const freq = root.querySelector('select[name="frequency"]') as HTMLSelectElement;
+  expect(freq).toBeTruthy();
+  freq.value = 'weekly'; freq.dispatchEvent(new Event('change'));
+
+  const evPromise = new Promise<CustomEvent<{ id: string; input: { name: string; obligations?: { rate?: { amount: number; frequency?: string }; label?: string }[] } }>>((resolve) => el.addEventListener('contract-save', (e) => resolve(e as CustomEvent<{ id: string; input: { name: string; obligations?: { rate?: { amount: number; frequency?: string }; label?: string }[] } }>)));
     (root.querySelector('form') as HTMLFormElement).dispatchEvent(new Event('submit', { cancelable: true, bubbles: true }));
     const ev = await evPromise;
     expect(ev.detail.input.name).toBe('Huur nieuw');
   expect(ev.detail.input.obligations?.[0].rate?.amount).toBe(1200);
+  expect(ev.detail.input.obligations?.[0].rate?.frequency).toBe('weekly');
     expect(ev.detail.input.obligations?.[0].label).toBe('Huur');
   });
 });

--- a/frontend/tests/contractForm.test.ts
+++ b/frontend/tests/contractForm.test.ts
@@ -13,11 +13,15 @@ describe('contract-form', () => {
 
     const name = el.shadowRoot!.querySelector('input[name="name"]') as HTMLInputElement;
     const acc = el.shadowRoot!.querySelector('input[name="accountNumber"]') as HTMLInputElement;
-    const desc = el.shadowRoot!.querySelector('textarea[name="description"]') as HTMLTextAreaElement;
+  const desc = el.shadowRoot!.querySelector('textarea[name="description"]') as HTMLTextAreaElement;
+  const amount = el.shadowRoot!.querySelector('input[name="amount"]') as HTMLInputElement;
+  const olab = el.shadowRoot!.querySelector('input[name="obligationLabel"]') as HTMLInputElement;
 
     name.value = 'Verzekering'; name.dispatchEvent(new Event('input'));
     acc.value = 'NL11BANK0000000001'; acc.dispatchEvent(new Event('input'));
     desc.value = 'WA autoverzekering'; desc.dispatchEvent(new Event('input'));
+  amount.value = '89.95'; amount.dispatchEvent(new Event('input'));
+  olab.value = 'Autoverzekering per maand'; olab.dispatchEvent(new Event('input'));
 
     const evPromise = new Promise<CustomEvent>((resolve) => {
       el.addEventListener('contract-submit', (e) => resolve(e as CustomEvent));
@@ -29,9 +33,14 @@ describe('contract-form', () => {
     expect(ev.detail.name).toBe('Verzekering');
     expect(ev.detail.accountNumber).toBe('NL11BANK0000000001');
     expect(ev.detail.description).toBe('WA autoverzekering');
+  expect(Array.isArray(ev.detail.obligations)).toBe(true);
+  expect(ev.detail.obligations![0].rate!.amount).toBeCloseTo(89.95, 2);
+  expect(ev.detail.obligations![0].label).toBe('Autoverzekering per maand');
 
     expect(name.value).toBe('');
     expect(acc.value).toBe('');
-    expect(desc.value).toBe('');
+  expect(desc.value).toBe('');
+  expect(amount.value).toBe('');
+  expect(olab.value).toBe('');
   });
 });

--- a/frontend/tests/contractList.test.ts
+++ b/frontend/tests/contractList.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import '../src/components/contract-list';
+
+function nextFrame() { return new Promise((r) => requestAnimationFrame(() => r(null))); }
+
+describe('contract-list', () => {
+  it('shows Doorlopend with amount and periodicity for recurring contracts', async () => {
+    const el = document.createElement('contract-list') as HTMLElement & { contracts: { id: string; name: string; accountNumber: string; createdAt: string; obligations: { id: string; createdAt: string; rates: { id: string; amount: number; validFrom: string; createdAt: string; schedule: { type: 'recurring'; frequency: 'monthly' } }[] }[] }[] };
+    document.body.appendChild(el);
+    const nowIso = new Date().toISOString();
+    el.contracts = [{
+      id: 'c1',
+      name: 'Internet',
+      accountNumber: 'NL00TEST',
+      createdAt: nowIso,
+      obligations: [{
+        id: 'o1',
+        createdAt: nowIso,
+        rates: [{ id: 'r1', amount: 50, validFrom: nowIso, createdAt: nowIso, schedule: { type: 'recurring', frequency: 'monthly' } }]
+      }],
+    }];
+    await nextFrame();
+    const root = el.shadowRoot!;
+    const metas = Array.from(root.querySelectorAll('.meta')) as HTMLElement[];
+    const found = metas.some(m => /Doorlopend: € 50\.00 per maand/.test(m.textContent || ''));
+    expect(found).toBe(true);
+  });
+});

--- a/frontend/tests/contractsRepository.test.ts
+++ b/frontend/tests/contractsRepository.test.ts
@@ -4,11 +4,22 @@ import { createContractRepository } from '../src/storage/contractsRepository';
 describe('contracts repository (memory)', () => {
   it('adds and lists contracts', async () => {
     const repo = createContractRepository('memory');
-    const created = await repo.add({ name: 'Huur', accountNumber: 'NL00BANK0123456789' });
+  const created = await repo.add({ name: 'Huur', accountNumber: 'NL00BANK0123456789', obligations: [{ rate: { amount: 1200 }, label: 'Huur' }] });
     expect(created.id).toBeDefined();
 
     const list = await repo.list();
     expect(list.length).toBe(1);
     expect(list[0].name).toBe('Huur');
+  expect(list[0].obligations?.[0].rates?.[0].amount).toBe(1200);
+  });
+
+  it('updates amount when provided', async () => {
+    const repo = createContractRepository('memory');
+  const created = await repo.add({ name: 'Internet', accountNumber: 'NL00BANK0000000002', obligations: [{ rate: { amount: 50 }, label: 'Abonnement' }] });
+  const firstId = created.obligations![0].id;
+  const updated = await repo.update(created.id, { name: 'Internet', accountNumber: 'NL00BANK0000000002', obligations: [{ id: firstId, rate: { amount: 55 }, label: 'Abonnement' }] });
+  expect(updated.obligations?.[0].rates?.slice(-1)[0].amount).toBe(55);
+    const list = await repo.list();
+  expect(list.find(c => c.id === created.id)!.obligations?.[0].rates?.slice(-1)[0].amount).toBe(55);
   });
 });


### PR DESCRIPTION
This PR improves the contracts overview and redesigns the edit dialog for better UX and accessibility.

Overview (contract-list)

Recurring (doorlopend): show explicit periodicity, e.g. "Doorlopend: € X,XX per maand".
Mixed frequencies: render combined, e.g. "Doorlopend: € A per maand + € B per kwartaal".
Installments: show total and number of terms, e.g. "Termijnen: € Y,YY (n termijnen)".
Robust selection of display rate (active or latest); no double counting of legacy obligation-level amounts.
Legacy fallbacks: use rate.frequency, schedule.frequency, obligation.frequency, or infer from label text (e.g., "maandelijkse kosten").
Edit dialog (contract-edit)

Accessible modal with role="dialog", aria-modal, header with close button, focus trap, and Esc to close.
Structured fieldsets and labels, better spacing, sticky actions, and visual polish.
Tests & Docs

Added contractList.test.ts and expanded tests remain green.
Updated [frontend-components.md](vscode-file://vscode-app/c:/Users/Alex/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to reflect list summary logic and a11y changes.
CHANGELOG entry added.
Notes

Markdown files may trigger MD013 (line-length) warnings; can be resolved in a follow-up by wrapping or relaxing the rule.